### PR TITLE
refactor(context): rename WarehouseContext to VaporSeaIndustryContext…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - EVE_CLIENT_SECRET=${EVE_CLIENT_SECRET}
       - EVE_CALLBACK_URI=http://localhost/login/oauth2/code/eve
       - CORPORATION_ID=${CORPORATION_ID}
+      - DEFAULT_PRINCIPAL=${DEFAULT_PRINCIPAL}
     volumes:
       - ${PWD}/config:/app/config
       - ${PWD}/data:/app/data

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,7 @@ import Items from './pages/Items';
 import Item from './pages/Item';
 import ExtraCost from './pages/ExtraCost';
 import MarketOrders from './pages/MarketOrders';
-import { WarehouseProvider } from './context/WarehouseContext';
+import { VaporSeaIndustryProvider } from './context/VaporSeaIndustryContext';
 import EntryPage from './pages/EntryPage.tsx';
 import ConfigureProduct from './pages/ConfigureProduct';
 import SPAIError from './pages/SPAIError';
@@ -33,7 +33,7 @@ const App: React.FC = () => {
       const hasToken = document.cookie.split(';').some((cookie) => 
         cookie.trim().startsWith('EVETokenExpiry=')
       );
-      
+
       if (hasToken) {
         try {
           const response = await fetch('/api/user/me');
@@ -76,7 +76,7 @@ const App: React.FC = () => {
       <EntryPage isVisible={!isAuthenticated} />
       {isAuthenticated && (
         <Router>
-          <WarehouseProvider>
+          <VaporSeaIndustryProvider>
             <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
               <Header/>
               <Box sx={{ display: 'flex', flex: 1 }}>
@@ -118,7 +118,7 @@ const App: React.FC = () => {
                 </Box>
               </Box>
             </Box>
-          </WarehouseProvider>
+          </VaporSeaIndustryProvider>
         </Router>
       )}
     </ThemeProvider>

--- a/frontend/src/context/VaporSeaIndustryContext.tsx
+++ b/frontend/src/context/VaporSeaIndustryContext.tsx
@@ -1,7 +1,8 @@
 import React, { createContext, useContext, useState, ReactNode } from 'react';
 import { BlueprintData } from '../types/blueprint';
 
-interface WarehouseContextType {
+interface VaporSeaIndustryContextType {
+  // Original WarehouseContext state
   nameFilter: string;
   setNameFilter: (filter: string) => void;
   lastScrollPosition: number;
@@ -16,23 +17,38 @@ interface WarehouseContextType {
   processPromise: Promise<void> | null;
   fetchAll: () => Promise<void>;
   processWarehouse: () => Promise<void>;
+  
+  // New state for Products -> Items
+  productsPage: number;
+  setProductsPage: (page: number) => void;
+  productsPageSize: number;
+  setProductsPageSize: (pageSize: number) => void;
+  
+  // New state for Items -> Item
+  itemsPage: number;
+  setItemsPage: (page: number) => void;
+  itemsPageSize: number;
+  setItemsPageSize: (pageSize: number) => void;
+  itemsSearchField: string;
+  setItemsSearchField: (search: string) => void;
 }
 
-const WarehouseContext = createContext<WarehouseContextType | undefined>(undefined);
+const VaporSeaIndustryContext = createContext<VaporSeaIndustryContextType | undefined>(undefined);
 
-export const useWarehouse = () => {
-  const context = useContext(WarehouseContext);
+export const useVaporSeaIndustry = () => {
+  const context = useContext(VaporSeaIndustryContext);
   if (!context) {
-    throw new Error('useWarehouse must be used within a WarehouseProvider');
+    throw new Error('useVaporSeaIndustry must be used within a VaporSeaIndustryProvider');
   }
   return context;
 };
 
-interface WarehouseProviderProps {
+interface VaporSeaIndustryProviderProps {
   children: ReactNode;
 }
 
-export const WarehouseProvider: React.FC<WarehouseProviderProps> = ({ children }) => {
+export const VaporSeaIndustryProvider: React.FC<VaporSeaIndustryProviderProps> = ({ children }) => {
+  // Original WarehouseContext state
   const [nameFilter, setNameFilter] = useState('');
   const [lastScrollPosition, setLastScrollPosition] = useState(0);
   const [prefetchedProducts] = useState<Record<string, BlueprintData | null>>({});
@@ -40,6 +56,15 @@ export const WarehouseProvider: React.FC<WarehouseProviderProps> = ({ children }
   const [isProcessing, setIsProcessing] = useState(false);
   const [refreshPromise, setRefreshPromise] = useState<Promise<void> | null>(null);
   const [processPromise, setProcessPromise] = useState<Promise<void> | null>(null);
+  
+  // New state for Products -> Items
+  const [productsPage, setProductsPage] = useState(0);
+  const [productsPageSize, setProductsPageSize] = useState(20);
+  
+  // New state for Items -> Item
+  const [itemsPage, setItemsPage] = useState(0);
+  const [itemsPageSize, setItemsPageSize] = useState(20);
+  const [itemsSearchField, setItemsSearchField] = useState('');
 
   const setPrefetchedProduct = (itemId: string, data: BlueprintData | null) => {
     prefetchedProducts[itemId] = data;
@@ -86,8 +111,9 @@ export const WarehouseProvider: React.FC<WarehouseProviderProps> = ({ children }
   };
 
   return (
-    <WarehouseContext.Provider
+    <VaporSeaIndustryContext.Provider
       value={{
+        // Original WarehouseContext values
         nameFilter,
         setNameFilter,
         lastScrollPosition,
@@ -102,9 +128,23 @@ export const WarehouseProvider: React.FC<WarehouseProviderProps> = ({ children }
         processPromise,
         fetchAll,
         processWarehouse,
+        
+        // New values for Products -> Items
+        productsPage,
+        setProductsPage,
+        productsPageSize,
+        setProductsPageSize,
+        
+        // New values for Items -> Item
+        itemsPage,
+        setItemsPage,
+        itemsPageSize,
+        setItemsPageSize,
+        itemsSearchField,
+        setItemsSearchField,
       }}
     >
       {children}
-    </WarehouseContext.Provider>
+    </VaporSeaIndustryContext.Provider>
   );
-}; 
+};

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -1,10 +1,49 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Box, Card, CardContent, Typography, CardActionArea, Grid } from '@mui/material';
-import { People as PeopleIcon, AttachMoney as MoneyIcon, Block as BlockIcon } from '@mui/icons-material';
+import { Box, Card, CardContent, Typography, CardActionArea, Grid, Snackbar, Alert } from '@mui/material';
+import { People as PeopleIcon, AttachMoney as MoneyIcon, Block as BlockIcon, Refresh as RefreshIcon } from '@mui/icons-material';
 
 const Admin: React.FC = () => {
   const navigate = useNavigate();
+  const [notification, setNotification] = useState<{open: boolean; message: string; severity: 'success' | 'error'}>({
+    open: false,
+    message: '',
+    severity: 'success'
+  });
+
+  const handleStoreTokens = async () => {
+    try {
+      const response = await fetch('/api/data/store-tokens', {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({})
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to store tokens');
+      }
+
+      setNotification({
+        open: true,
+        message: 'Tokens stored successfully!',
+        severity: 'success'
+      });
+    } catch (error) {
+      console.error('Error storing tokens:', error);
+      setNotification({
+        open: true,
+        message: 'Failed to store tokens. Please try again.',
+        severity: 'error'
+      });
+    }
+  };
+
+  const handleCloseNotification = () => {
+    setNotification({...notification, open: false});
+  };
 
   return (
     <Box sx={{ p: 3 }}>
@@ -131,7 +170,64 @@ const Admin: React.FC = () => {
             </CardActionArea>
           </Card>
         </Box>
+        <Box
+          sx={{
+            width: '100%',
+            '@media (min-width:600px)': {
+              width: '50%',
+            },
+            '@media (min-width:900px)': {
+              width: '33.33%',
+            },
+            p: 1,
+          }}
+        >
+          <Card 
+            sx={{ 
+              height: '100%',
+              bgcolor: 'rgba(26, 26, 26, 0.95)',
+              backdropFilter: 'blur(10px)',
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+              '&:hover': {
+                bgcolor: 'rgba(40, 40, 40, 0.95)',
+              },
+            }}
+          >
+            <CardActionArea 
+              onClick={handleStoreTokens}
+              sx={{ height: '100%' }}
+            >
+              <CardContent sx={{ textAlign: 'center' }}>
+                <RefreshIcon sx={{ fontSize: 60, color: 'white', mb: 2 }} />
+                <Typography variant="h5" component="div" color="white">
+                  Store API Tokens
+                </Typography>
+                <Typography variant="body2" color="rgba(255, 255, 255, 0.7)" sx={{ mt: 1 }}>
+                  This only needs to be done once during initial setup.
+                </Typography>
+                <Typography variant="body2" color="rgba(255, 255, 255, 0.7)" sx={{ mt: 1 }}>
+                  The backend will automatically handle token refreshes.
+                </Typography>
+              </CardContent>
+            </CardActionArea>
+          </Card>
+        </Box>
       </Grid>
+
+      <Snackbar 
+        open={notification.open} 
+        autoHideDuration={6000} 
+        onClose={handleCloseNotification}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert 
+          onClose={handleCloseNotification} 
+          severity={notification.severity}
+          sx={{ width: '100%' }}
+        >
+          {notification.message}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 };

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -4,7 +4,7 @@ import {
   Refresh as RefreshIcon,
   PlayArrow as PlayArrowIcon,
 } from '@mui/icons-material';
-import { useWarehouse } from '../context/WarehouseContext.tsx';
+import { useVaporSeaIndustry } from '../context/VaporSeaIndustryContext';
 
 interface WalletBalance {
   division: number;
@@ -18,8 +18,8 @@ function Dashboard() {
     fetchAll, 
     processWarehouse,
     setIsRefreshing
-  } = useWarehouse();
-  
+  } = useVaporSeaIndustry();
+
   const [stats, setStats] = useState<{
     totalOrders: Record<number, number>;
     totalSell: Record<number, number>;
@@ -34,7 +34,7 @@ function Dashboard() {
       try {
         const response = await fetch('/api/data/fetch-status');
         if (!response.ok) return;
-        
+
         const data = await response.json();
         if (data.status === 'Fetching in progress') {
           setIsRefreshing(true);
@@ -51,7 +51,7 @@ function Dashboard() {
               clearInterval(interval);
             }
           }, 5000);
-          
+
           return () => clearInterval(interval);
         }
       } catch (error) {

--- a/frontend/src/pages/Items.tsx
+++ b/frontend/src/pages/Items.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, ReactNode } from 'react';
+import { useVaporSeaIndustry } from '../context/VaporSeaIndustryContext';
 import {
   Box,
   Table,
@@ -33,13 +34,11 @@ interface ItemResponse {
 }
 
 const Items: React.FC = () => {
+  const { itemsPage, setItemsPage, itemsPageSize, setItemsPageSize, itemsSearchField, setItemsSearchField } = useVaporSeaIndustry();
   const [items, setItems] = useState<Item[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(20);
   const [totalElements, setTotalElements] = useState(0);
-  const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const searchFieldRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
@@ -68,45 +67,45 @@ const Items: React.FC = () => {
   // Update debounced search value after delay
   useEffect(() => {
     const timer = setTimeout(() => {
-      setDebouncedSearch(search);
+      setDebouncedSearch(itemsSearchField);
     }, 300);
 
     return () => {
       clearTimeout(timer);
     };
-  }, [search]);
+  }, [itemsSearchField]);
 
   // Fetch items when debounced search changes
   useEffect(() => {
-    fetchItems(page, rowsPerPage, debouncedSearch);
-  }, [page, rowsPerPage, debouncedSearch]);
+    fetchItems(itemsPage, itemsPageSize, debouncedSearch);
+  }, [itemsPage, itemsPageSize, debouncedSearch]);
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setSearch(event.target.value);
-    setPage(0); // Reset to first page when search changes
+    setItemsSearchField(event.target.value);
+    setItemsPage(0); // Reset to first page when search changes
   };
 
   const handleClearSearch = () => {
-    setSearch('');
+    setItemsSearchField('');
     // Focus the search field after clearing
     searchFieldRef.current?.focus();
   };
 
   const handleChangePage = (_event: unknown, newPage: number) => {
-    setPage(newPage);
+    setItemsPage(newPage);
   };
 
   const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10));
-    setPage(0);
+    setItemsPageSize(parseInt(event.target.value, 10));
+    setItemsPage(0);
   };
 
   const parseDescription = (text: string | null) => {
     if (!text) return '-';
-    
+
     // First replace \r\n with newlines
     const textWithNewlines = text.replace(/\\r\\n/g, '\n');
-    
+
     // Replace <a href=showinfo:ID>Text</a> with links
     const linkRegex = /<a href=showinfo:(\d+)>([^<]+)<\/a>/g;
     const parts: (string | ReactNode)[] = [];
@@ -118,7 +117,7 @@ const Items: React.FC = () => {
       if (match.index > lastIndex) {
         parts.push(textWithNewlines.substring(lastIndex, match.index));
       }
-      
+
       // Add the link
       const typeId = match[1];
       const linkText = match[2];
@@ -132,7 +131,7 @@ const Items: React.FC = () => {
           {linkText}
         </Link>
       );
-      
+
       lastIndex = match.index + match[0].length;
     }
 
@@ -172,7 +171,7 @@ const Items: React.FC = () => {
           fullWidth
           variant="outlined"
           placeholder="Search items..."
-          value={search}
+          value={itemsSearchField}
           onChange={handleSearchChange}
           autoFocus
           InputProps={{
@@ -181,7 +180,7 @@ const Items: React.FC = () => {
                 <SearchIcon />
               </InputAdornment>
             ),
-            endAdornment: search && (
+            endAdornment: itemsSearchField && (
               <InputAdornment position="end">
                 <IconButton onClick={handleClearSearch} edge="end">
                   <ClearIcon />
@@ -237,9 +236,9 @@ const Items: React.FC = () => {
       <TablePagination
         component="div"
         count={totalElements}
-        page={page}
+        page={itemsPage}
         onPageChange={handleChangePage}
-        rowsPerPage={rowsPerPage}
+        rowsPerPage={itemsPageSize}
         onRowsPerPageChange={handleChangeRowsPerPage}
         rowsPerPageOptions={[10, 20, 50, 100]}
       />

--- a/frontend/src/pages/Products.tsx
+++ b/frontend/src/pages/Products.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useVaporSeaIndustry } from '../context/VaporSeaIndustryContext';
 import {
   Box,
   Paper,
@@ -40,11 +41,10 @@ interface ProductResponse {
 
 export const Products: React.FC = () => {
   const navigate = useNavigate();
+  const { productsPage, setProductsPage, productsPageSize, setProductsPageSize } = useVaporSeaIndustry();
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(20);
   const [totalElements, setTotalElements] = useState(0);
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
 
@@ -66,21 +66,21 @@ export const Products: React.FC = () => {
   };
 
   useEffect(() => {
-    fetchProducts(page, rowsPerPage);
-  }, [page, rowsPerPage]);
+    fetchProducts(productsPage, productsPageSize);
+  }, [productsPage, productsPageSize]);
 
   const handleChangePage = (_event: unknown, newPage: number) => {
-    setPage(newPage);
+    setProductsPage(newPage);
   };
 
   const handleChangeRowsPerPage = (event: SelectChangeEvent<number>) => {
-    setRowsPerPage(Number(event.target.value));
-    setPage(0);
+    setProductsPageSize(Number(event.target.value));
+    setProductsPage(0);
   };
 
   const handleTablePaginationRowsPerPageChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10));
-    setPage(0);
+    setProductsPageSize(parseInt(event.target.value, 10));
+    setProductsPage(0);
   };
 
   if (loading) {
@@ -117,7 +117,7 @@ export const Products: React.FC = () => {
           <FormControl size="small" sx={{ minWidth: 120 }}>
             <InputLabel>Page Size</InputLabel>
             <Select
-              value={rowsPerPage}
+              value={productsPageSize}
               label="Page Size"
               onChange={handleChangeRowsPerPage}
             >
@@ -188,9 +188,9 @@ export const Products: React.FC = () => {
       <TablePagination
         component="div"
         count={totalElements}
-        page={page}
+        page={productsPage}
         onPageChange={handleChangePage}
-        rowsPerPage={rowsPerPage}
+        rowsPerPage={productsPageSize}
         onRowsPerPageChange={handleTablePaginationRowsPerPageChange}
         rowsPerPageOptions={[10, 20, 50, 100]}
       />

--- a/frontend/src/pages/Warehouse.tsx
+++ b/frontend/src/pages/Warehouse.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useWarehouse } from '../context/WarehouseContext.tsx';
+import { useVaporSeaIndustry } from '../context/VaporSeaIndustryContext';
 import {
   Box,
   Paper,
@@ -47,7 +47,7 @@ export const Warehouse: React.FC = () => {
     lastScrollPosition, 
     setLastScrollPosition,
     setPrefetchedProduct 
-  } = useWarehouse();
+  } = useVaporSeaIndustry();
   const containerRef = useRef<HTMLDivElement>(null);
   const [items, setItems] = useState<InventoryItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -128,7 +128,7 @@ export const Warehouse: React.FC = () => {
 
   const handleSave = async (itemId: number) => {
     if (!editingItem) return;
-    
+
     try {
       setSaving(itemId);
       const response = await fetch('/api/warehouse', {
@@ -192,7 +192,7 @@ export const Warehouse: React.FC = () => {
     if (target.closest('button') || target.closest('td:last-child')) {
       return; // Don't navigate if clicking edit buttons or their container
     }
-    
+
     if(editingItem?.itemId === itemId) {
       return;
     }


### PR DESCRIPTION
… and add stateful navigation

This commit implements two major changes:

1. Renames WarehouseContext to VaporSeaIndustryContext to better reflect the application's domain
   - Created new VaporSeaIndustryContext.tsx file
   - Updated all imports and usages across the application
   - Maintained all existing functionality from the original context

2. Adds stateful navigation for Products and Items pages
   - Added state management for Products -> Items: - productsPage: tracks current page - productsPageSize: tracks page size
   - Added state management for Items -> Item:
     - itemsPage: tracks current page
     - itemsPageSize: tracks page size - itemsSearchField: preserves search terms

These changes improve user experience by maintaining navigation state when moving between pages, allowing users to return to their previous position in lists after viewing details.